### PR TITLE
Add functions multiplysign and copysign.

### DIFF
--- a/avx.hpp
+++ b/avx.hpp
@@ -151,6 +151,16 @@ class simd<float, simd_abi::avx> {
   }
 };
 
+SIMD_ALWAYS_INLINE inline simd<float, simd_abi::avx> multiplysign(simd<float, simd_abi::avx> const& a, simd<float, simd_abi::avx> const& b) {
+  __m256 const sign_mask = _mm256_set1_ps(-0.f);
+  return simd<float, simd_abi::avx>(_mm256_xor_ps(a.get(), _mm256_and_ps(sign_mask, b.get())));
+}
+
+SIMD_ALWAYS_INLINE inline simd<float, simd_abi::avx> copysign(simd<float, simd_abi::avx> const& a, simd<float, simd_abi::avx> const& b) {
+  __m256 const sign_mask = _mm256_set1_ps(-0.);
+  return simd<float, simd_abi::avx>(_mm256_xor_ps(_mm256_andnot_ps(sign_mask, a.get()), _mm256_and_ps(sign_mask, b.get())));
+}
+
 SIMD_ALWAYS_INLINE inline simd<float, simd_abi::avx> abs(simd<float, simd_abi::avx> const& a) {
   __m256 sign_mask = _mm256_set1_ps(-0.f);  // -0.f = 1 << 31
   return simd<float, simd_abi::avx>(_mm256_andnot_ps(sign_mask, a.get()));
@@ -167,6 +177,10 @@ SIMD_ALWAYS_INLINE inline simd<float, simd_abi::avx> cbrt(simd<float, simd_abi::
 
 SIMD_ALWAYS_INLINE inline simd<float, simd_abi::avx> exp(simd<float, simd_abi::avx> const& a) {
   return simd<float, simd_abi::avx>(_mm256_exp_ps(a.get()));
+}
+
+SIMD_ALWAYS_INLINE inline simd<float, simd_abi::avx> log(simd<float, simd_abi::avx> const& a) {
+  return simd<float, simd_abi::avx>(_mm256_log_ps(a.get()));
 }
 #endif
 
@@ -301,6 +315,16 @@ class simd<double, simd_abi::avx> {
   }
 };
 
+SIMD_ALWAYS_INLINE inline simd<double, simd_abi::avx> multiplysign(simd<double, simd_abi::avx> const& a, simd<double, simd_abi::avx> const& b) {
+  __m256d const sign_mask = _mm256_set1_pd(-0.f);
+  return simd<double, simd_abi::avx>(_mm256_xor_pd(a.get(), _mm256_and_pd(sign_mask, b.get())));
+}
+
+SIMD_ALWAYS_INLINE inline simd<double, simd_abi::avx> copysign(simd<double, simd_abi::avx> const& a, simd<double, simd_abi::avx> const& b) {
+  __m256d const sign_mask = _mm256_set1_pd(-0.f);
+  return simd<double, simd_abi::avx>(_mm256_xor_pd(_mm256_andnot_pd(sign_mask, a.get()), _mm256_and_pd(sign_mask, b.get())));
+}
+
 SIMD_ALWAYS_INLINE inline simd<double, simd_abi::avx> abs(simd<double, simd_abi::avx> const& a) {
   __m256d const sign_mask = _mm256_set1_pd(-0.f);  // -0.f = 1 << 31
   return simd<double, simd_abi::avx>(_mm256_andnot_pd(sign_mask, a.get()));
@@ -317,6 +341,10 @@ SIMD_ALWAYS_INLINE inline simd<double, simd_abi::avx> cbrt(simd<double, simd_abi
 
 SIMD_ALWAYS_INLINE inline simd<double, simd_abi::avx> exp(simd<double, simd_abi::avx> const& a) {
   return simd<double, simd_abi::avx>(_mm256_exp_pd(a.get()));
+}
+
+SIMD_ALWAYS_INLINE inline simd<double, simd_abi::avx> log(simd<double, simd_abi::avx> const& a) {
+  return simd<double, simd_abi::avx>(_mm256_log_pd(a.get()));
 }
 #endif
 

--- a/avx512.hpp
+++ b/avx512.hpp
@@ -153,6 +153,16 @@ class simd<float, simd_abi::avx512> {
   }
 };
 
+SIMD_ALWAYS_INLINE inline simd<float, simd_abi::avx512> multiplysign(simd<float, simd_abi::avx512> const& a, simd<float, simd_abi::avx512> const& b) {
+  static simd<float, simd_abi::avx512> sign_mask(-0.f);
+  return simd<float, simd_abi::avx512>(_mm512_xor_ps(a.get(), _mm512_and_ps(sign_mask.get(), b.get())));
+}
+
+SIMD_ALWAYS_INLINE inline simd<float, simd_abi::avx512> copysign(simd<float, simd_abi::avx512> const& a, simd<float, simd_abi::avx512> const& b) {
+  static simd<float, simd_abi::avx512> sign_mask(-0.f);
+  return simd<float, simd_abi::avx512>(_mm512_xor_ps(_mm512_andnot_ps(sign_mask.get(), a.get()) , _mm512_and_ps(sign_mask.get(), b.get())));
+}
+
 SIMD_ALWAYS_INLINE inline simd<float, simd_abi::avx512> abs(simd<float, simd_abi::avx512> const& a) {
   __m512 const rhs = a.get();
   return reinterpret_cast<__m512>(_mm512_and_epi32(reinterpret_cast<__m512i>(rhs), _mm512_set1_epi32(0x7fffffff)));
@@ -169,6 +179,10 @@ SIMD_ALWAYS_INLINE inline simd<float, simd_abi::avx512> cbrt(simd<float, simd_ab
 
 SIMD_ALWAYS_INLINE inline simd<float, simd_abi::avx512> exp(simd<float, simd_abi::avx512> const& a) {
   return simd<float, simd_abi::avx512>(_mm512_exp_ps(a.get()));
+}
+
+SIMD_ALWAYS_INLINE inline simd<float, simd_abi::avx512> log(simd<float, simd_abi::avx512> const& a) {
+  return simd<float, simd_abi::avx512>(_mm512_log_ps(a.get()));
 }
 #endif
 
@@ -299,6 +313,16 @@ class simd<double, simd_abi::avx512> {
   }
 };
 
+SIMD_ALWAYS_INLINE inline simd<double, simd_abi::avx512> multiplysign(simd<double, simd_abi::avx512> const& a, simd<double, simd_abi::avx512> const& b) {
+  static simd<double, simd_abi::avx512> sign_mask(-0.0);
+  return simd<double, simd_abi::avx512>(_mm512_xor_pd(a.get(), _mm512_and_pd(sign_mask.get(), b.get())));
+}
+
+SIMD_ALWAYS_INLINE inline simd<double, simd_abi::avx512> copysign(simd<double, simd_abi::avx512> const& a, simd<double, simd_abi::avx512> const& b) {
+  static simd<double, simd_abi::avx512> sign_mask(-0.0);
+  return simd<double, simd_abi::avx512>(_mm512_xor_pd(_mm512_andnot_pd(sign_mask.get(), a.get()) , _mm512_and_pd(sign_mask.get(), b.get())));
+}
+
 SIMD_ALWAYS_INLINE inline simd<double, simd_abi::avx512> abs(simd<double, simd_abi::avx512> const& a) {
   __m512d const rhs = a.get();
   return reinterpret_cast<__m512d>(_mm512_and_epi64(_mm512_set1_epi64(0x7FFFFFFFFFFFFFFF),
@@ -316,6 +340,10 @@ SIMD_ALWAYS_INLINE inline simd<double, simd_abi::avx512> cbrt(simd<double, simd_
 
 SIMD_ALWAYS_INLINE inline simd<double, simd_abi::avx512> exp(simd<double, simd_abi::avx512> const& a) {
   return simd<double, simd_abi::avx512>(_mm512_exp_pd(a.get()));
+}
+
+SIMD_ALWAYS_INLINE inline simd<double, simd_abi::avx512> log(simd<double, simd_abi::avx512> const& a) {
+  return simd<double, simd_abi::avx512>(_mm512_log_pd(a.get()));
 }
 #endif
 

--- a/simd_common.hpp
+++ b/simd_common.hpp
@@ -165,6 +165,37 @@ SIMD_ALWAYS_INLINE SIMD_HOST_DEVICE inline simd<T, Abi> operator/(simd<T, Abi> c
 }
 
 template <class T, class Abi>
+SIMD_ALWAYS_INLINE SIMD_HOST_DEVICE inline simd<T, Abi> multiplysign(simd<T, Abi> a, simd<T, Abi> b) {
+  T tmp_a[simd<T, Abi>::size()];
+  T tmp_b[simd<T, Abi>::size()];
+  a.copy_to(tmp_a, element_aligned_tag());
+  b.copy_to(tmp_b, element_aligned_tag());
+  for (int i = 0; i < simd<T, Abi>::size(); ++i) tmp_a[i] = tmp_a[i]*std::copysign(1.0, tmp_b[i]);
+  a.copy_from(tmp_a, element_aligned_tag());
+  return a;
+}
+
+template <class T, class Abi>
+SIMD_ALWAYS_INLINE SIMD_HOST_DEVICE inline simd<T, Abi> copysign(simd<T, Abi> a, simd<T, Abi> b) {
+  T tmp_a[simd<T, Abi>::size()];
+  T tmp_b[simd<T, Abi>::size()];
+  a.copy_to(tmp_a, element_aligned_tag());
+  b.copy_to(tmp_b, element_aligned_tag());
+  for (int i = 0; i < simd<T, Abi>::size(); ++i) tmp_a[i] = std::copysign(tmp_a[i], tmp_b[i]);
+  a.copy_from(tmp_a, element_aligned_tag());
+  return a;
+}
+
+template <class T, class Abi>
+SIMD_ALWAYS_INLINE SIMD_HOST_DEVICE inline simd<T, Abi> abs(simd<T, Abi> a) {
+  T tmp[simd<T, Abi>::size()];
+  a.copy_to(tmp, element_aligned_tag());
+  for (int i = 0; i < simd<T, Abi>::size(); ++i) tmp[i] = std::abs(tmp[i]);
+  a.copy_from(tmp, element_aligned_tag());
+  return a;
+}
+
+template <class T, class Abi>
 SIMD_ALWAYS_INLINE SIMD_HOST_DEVICE inline simd<T, Abi> cbrt(simd<T, Abi> a) {
   T tmp[simd<T, Abi>::size()];
   a.copy_to(tmp, element_aligned_tag());

--- a/sse.hpp
+++ b/sse.hpp
@@ -171,6 +171,16 @@ class simd<float, simd_abi::sse> {
   }
 };
 
+SIMD_ALWAYS_INLINE inline simd<float, simd_abi::sse> multiplysign(simd<float, simd_abi::sse> const& a, simd<float, simd_abi::sse> const& b) {
+  __m128 const sign_mask = _mm_set1_ps(-0.);
+  return simd<float, simd_abi::sse>(_mm_xor_ps(a.get(), _mm_and_ps(sign_mask, b.get())));
+}
+
+SIMD_ALWAYS_INLINE inline simd<float, simd_abi::sse> copysign(simd<float, simd_abi::sse> const& a, simd<float, simd_abi::sse> const& b) {
+  __m128 const sign_mask = _mm_set1_ps(-0.);
+  return simd<float, simd_abi::sse>(_mm_xor_ps(_mm_andnot_ps(sign_mask, a.get()), _mm_and_ps(sign_mask, b.get())));
+}
+
 SIMD_ALWAYS_INLINE inline simd<float, simd_abi::sse> abs(simd<float, simd_abi::sse> const& a) {
   __m128 const sign_mask = _mm_set1_ps(-0.f);  // -0.f = 1 << 31
   return simd<float, simd_abi::sse>(_mm_andnot_ps(sign_mask, a.get()));
@@ -187,6 +197,10 @@ SIMD_ALWAYS_INLINE inline simd<float, simd_abi::sse> cbrt(simd<float, simd_abi::
 
 SIMD_ALWAYS_INLINE inline simd<float, simd_abi::sse> exp(simd<float, simd_abi::sse> const& a) {
   return simd<float, simd_abi::sse>(_mm_exp_ps(a.get()));
+}
+
+SIMD_ALWAYS_INLINE inline simd<float, simd_abi::sse> log(simd<float, simd_abi::sse> const& a) {
+  return simd<float, simd_abi::sse>(_mm_log_ps(a.get()));
 }
 #endif
 
@@ -323,6 +337,16 @@ class simd<double, simd_abi::sse> {
   }
 };
 
+SIMD_ALWAYS_INLINE inline simd<double, simd_abi::sse> multiplysign(simd<double, simd_abi::sse> const& a, simd<double, simd_abi::sse> const& b) {
+  __m128d const sign_mask = _mm_set1_pd(-0.);
+  return simd<double, simd_abi::sse>(_mm_xor_pd(a.get(), _mm_and_pd(sign_mask, b.get())));
+}
+
+SIMD_ALWAYS_INLINE inline simd<double, simd_abi::sse> copysign(simd<double, simd_abi::sse> const& a, simd<double, simd_abi::sse> const& b) {
+  __m128d const sign_mask = _mm_set1_pd(-0.);
+  return simd<double, simd_abi::sse>(_mm_xor_pd(_mm_andnot_pd(sign_mask, a.get()), _mm_and_pd(sign_mask, b.get())));
+}
+
 SIMD_ALWAYS_INLINE inline simd<double, simd_abi::sse> abs(simd<double, simd_abi::sse> const& a) {
   __m128d const sign_mask = _mm_set1_pd(-0.);  // -0. = 1 << 63
   return simd<double, simd_abi::sse>(_mm_andnot_pd(sign_mask, a.get()));
@@ -339,6 +363,10 @@ SIMD_ALWAYS_INLINE inline simd<double, simd_abi::sse> cbrt(simd<double, simd_abi
 
 SIMD_ALWAYS_INLINE inline simd<double, simd_abi::sse> exp(simd<double, simd_abi::sse> const& a) {
   return simd<double, simd_abi::sse>(_mm_exp_pd(a.get()));
+}
+
+SIMD_ALWAYS_INLINE inline simd<double, simd_abi::sse> log(simd<double, simd_abi::sse> const& a) {
+  return simd<double, simd_abi::sse>(_mm_log_pd(a.get()));
 }
 #endif
 


### PR DESCRIPTION
Specialized implementations are included for SSE, AVX, AVX512.
Fallback implementations are also included which should at least
work correctly (but not fast) for other instruction sets until
specialized implementations can be added.