### PR TITLE
Add strided constructors for SSE,AVX,AVX512

### DIFF
--- a/avx.hpp
+++ b/avx.hpp
@@ -115,9 +115,13 @@ class simd<float, simd_abi::avx> {
     return *this;
   }
   template <class Flags>
-  SIMD_ALWAYS_INLINE inline simd(float const* ptr, Flags flags) {
-    copy_from(ptr, flags);
-  }
+  SIMD_ALWAYS_INLINE inline simd(float const* ptr, Flags /*flags*/)
+    :m_value(_mm256_loadu_ps(ptr))
+  {}
+  SIMD_ALWAYS_INLINE inline simd(float const* ptr, int stride)
+    :m_value(_mm256_setr_ps(ptr[0],        ptr[stride],   ptr[2*stride], ptr[3*stride],
+                            ptr[4*stride], ptr[5*stride], ptr[6*stride], ptr[7*stride]))
+  {}
   SIMD_ALWAYS_INLINE inline constexpr simd(__m256 const& value_in)
     :m_value(value_in)
   {}
@@ -278,9 +282,12 @@ class simd<double, simd_abi::avx> {
     return *this;
   }
   template <class Flags>
-  SIMD_ALWAYS_INLINE inline simd(double const* ptr, Flags flags) {
-    copy_from(ptr, flags);
-  }
+  SIMD_ALWAYS_INLINE inline simd(double const* ptr, Flags flags)
+    :m_value(_mm256_loadu_pd(ptr))
+  {}
+  SIMD_ALWAYS_INLINE inline simd(double const* ptr, int stride)
+    :m_value(_mm256_setr_pd(ptr[0], ptr[stride], ptr[2*stride], ptr[3*stride]))
+  {}
   SIMD_ALWAYS_INLINE inline constexpr simd(__m256d const& value_in)
     :m_value(value_in)
   {}

--- a/avx512.hpp
+++ b/avx512.hpp
@@ -117,9 +117,15 @@ class simd<float, simd_abi::avx512> {
     return *this;
   }
   template <class Flags>
-  SIMD_ALWAYS_INLINE inline simd(float const* ptr, Flags flags) {
-    copy_from(ptr, flags);
-  }
+  SIMD_ALWAYS_INLINE inline simd(float const* ptr, Flags /*flags*/)
+    :m_value(_mm512_loadu_ps(ptr))
+  {}
+  SIMD_ALWAYS_INLINE inline simd(float const* ptr, int stride)
+    :m_value(_mm512_setr_ps(ptr[0],        ptr[stride],   ptr[2*stride], ptr[3*stride],
+                            ptr[4*stride], ptr[5*stride], ptr[6*stride], ptr[7*stride],
+                            ptr[8*stride], ptr[9*stride], ptr[10*stride], ptr[11*stride],
+                            ptr[12*stride], ptr[13*stride], ptr[14*stride], ptr[15*stride]))
+  {}
   SIMD_ALWAYS_INLINE inline constexpr simd(__m512 const& value_in)
     :m_value(value_in)
   {}
@@ -276,9 +282,13 @@ class simd<double, simd_abi::avx512> {
     return *this;
   }
   template <class Flags>
-  SIMD_ALWAYS_INLINE inline simd(double const* ptr, Flags flags) {
-    copy_from(ptr, flags);
-  }
+  SIMD_ALWAYS_INLINE inline simd(double const* ptr, Flags /*flags*/)
+    :m_value(_mm512_loadu_pd(ptr))
+  {}
+  SIMD_ALWAYS_INLINE inline simd(double const* ptr, int stride)
+    :m_value(_mm512_setr_pd(ptr[0],        ptr[stride],   ptr[2*stride], ptr[3*stride],
+                            ptr[4*stride], ptr[5*stride], ptr[6*stride], ptr[7*stride]))
+  {}
   SIMD_ALWAYS_INLINE inline constexpr simd(__m512d const& value_in)
     :m_value(value_in)
   {}

--- a/sse.hpp
+++ b/sse.hpp
@@ -135,9 +135,12 @@ class simd<float, simd_abi::sse> {
     return *this;
   }
   template <class Flags>
-  SIMD_ALWAYS_INLINE inline simd(float const* ptr, Flags flags) {
-    copy_from(ptr, flags);
-  }
+  SIMD_ALWAYS_INLINE inline simd(float const* ptr, Flags /*flags*/)
+    :m_value(_mm_loadu_ps(ptr))
+  {}
+  SIMD_ALWAYS_INLINE inline simd(float const* ptr, int stride)
+    :m_value(_mm_setr_ps(ptr[0], ptr[stride], ptr[2*stride], ptr[3*stride]))
+  {}
   SIMD_ALWAYS_INLINE inline constexpr simd(__m128 const& value_in)
     :m_value(value_in)
   {}
@@ -300,9 +303,12 @@ class simd<double, simd_abi::sse> {
     return *this;
   }
   template <class Flags>
-  SIMD_ALWAYS_INLINE inline simd(double const* ptr, Flags flags) {
-    copy_from(ptr, flags);
-  }
+  SIMD_ALWAYS_INLINE inline simd(double const* ptr, Flags /*flags*/)
+    :m_value(_mm_loadu_pd(ptr))
+  {}
+  SIMD_ALWAYS_INLINE inline simd(double const* ptr, int stride)
+    :m_value(_mm_setr_pd(ptr[0], ptr[stride]))
+  {}
   SIMD_ALWAYS_INLINE inline constexpr simd(__m128d const& value_in)
     :m_value(value_in)
   {}


### PR DESCRIPTION
Also alter the regular ptr constructors to use intrinsic in the
initializer list rather than calling copy_from in the body of
the constructors.