### PR TITLE
Feature/hip simd

### DIFF
--- a/hip_wavefront.hpp
+++ b/hip_wavefront.hpp
@@ -76,7 +76,7 @@ class hip_wavefront {
   }
 };
 
-}
+} // SIMD ABI
 
 template <class T, int N>
 class simd_storage<T, simd_abi::hip_wavefront<N>> {
@@ -215,24 +215,49 @@ class simd<T, simd_abi::hip_wavefront<N>> {
   }
 };
 
-template <class T, int N>
-SIMD_HIP_ALWAYS_INLINE SIMD_HOST_DEVICE simd<T, simd_abi::hip_wavefront<N>> abs(simd<T, simd_abi::hip_wavefront<N>> const& a) {
-  return simd<T, simd_abi::hip_wavefront<N>>(abs(a.get()));
+  // ABS
+template <int N>
+SIMD_HIP_ALWAYS_INLINE SIMD_HOST_DEVICE simd<float, simd_abi::hip_wavefront<N>> abs(simd<float, simd_abi::hip_wavefront<N>> const& a) {
+  return simd<float, simd_abi::hip_wavefront<N>>(fabsf(a.get()));
 }
 
-template <class T, int N>
-SIMD_HIP_ALWAYS_INLINE SIMD_HOST_DEVICE simd<T, simd_abi::hip_wavefront<N>> sqrt(simd<T, simd_abi::hip_wavefront<N>> const& a) {
-  return simd<T, simd_abi::hip_wavefront<N>>(sqrt(a.get()));
+template <int N>
+SIMD_HIP_ALWAYS_INLINE SIMD_HOST_DEVICE simd<double, simd_abi::hip_wavefront<N>> abs(simd<double, simd_abi::hip_wavefront<N>> const& a) {
+  return simd<double, simd_abi::hip_wavefront<N>>(fabs(a.get()));
 }
 
-template <class T, int N>
-SIMD_HIP_ALWAYS_INLINE SIMD_HOST_DEVICE simd<T, simd_abi::hip_wavefront<N>> cbrt(simd<T, simd_abi::hip_wavefront<N>> const& a) {
-  return simd<T, simd_abi::hip_wavefront<N>>(cbrt(a.get()));
+  // SQRT
+template <int N>
+SIMD_HIP_ALWAYS_INLINE SIMD_HOST_DEVICE simd<float, simd_abi::hip_wavefront<N>> sqrt(simd<float, simd_abi::hip_wavefront<N>> const& a) {
+  return simd<float, simd_abi::hip_wavefront<N>>(sqrtf(a.get()));
 }
 
-template <class T, int N>
-SIMD_HIP_ALWAYS_INLINE SIMD_HOST_DEVICE simd<T, simd_abi::hip_wavefront<N>> exp(simd<T, simd_abi::hip_wavefront<N>> const& a) {
-  return simd<T, simd_abi::hip_wavefront<N>>(exp(a.get()));
+template <int N>
+SIMD_HIP_ALWAYS_INLINE SIMD_HOST_DEVICE simd<double, simd_abi::hip_wavefront<N>> sqrt(simd<double, simd_abi::hip_wavefront<N>> const& a) {
+  return simd<double, simd_abi::hip_wavefront<N>>(sqrt(a.get()));
+}
+
+  // CBRT
+template <int N>
+SIMD_HIP_ALWAYS_INLINE SIMD_HOST_DEVICE simd<float, simd_abi::hip_wavefront<N>> cbrt(simd<float, simd_abi::hip_wavefront<N>> const& a) {
+  return simd<float, simd_abi::hip_wavefront<N>>(cbrtf(a.get()));
+}
+
+template <int N>
+SIMD_HIP_ALWAYS_INLINE SIMD_HOST_DEVICE simd<double, simd_abi::hip_wavefront<N>> cbrt(simd<double, simd_abi::hip_wavefront<N>> const& a) {
+  return simd<double, simd_abi::hip_wavefront<N>>(cbrt(a.get()));
+}
+
+  // EXP
+template <int N>
+SIMD_HIP_ALWAYS_INLINE SIMD_HOST_DEVICE simd<float, simd_abi::hip_wavefront<N>> exp(simd<float, simd_abi::hip_wavefront<N>> const& a) {
+  return simd<float, simd_abi::hip_wavefront<N>>(expf(a.get()));
+}
+
+  
+template <int N>
+SIMD_HIP_ALWAYS_INLINE SIMD_HOST_DEVICE simd<double, simd_abi::hip_wavefront<N>> exp(simd<double, simd_abi::hip_wavefront<N>> const& a) {
+  return simd<double, simd_abi::hip_wavefront<N>>(exp(a.get()));
 }
 
 template <class T, int N>
@@ -263,6 +288,6 @@ SIMD_HIP_ALWAYS_INLINE SIMD_HOST_DEVICE simd<T, simd_abi::hip_wavefront<N>> choo
   return simd<T, simd_abi::hip_wavefront<N>>(a.get() ? b.get() : c.get());
 }
 
-}
+} // SIMD_NAMESPACE
 
 #endif

--- a/hip_wavefront.hpp
+++ b/hip_wavefront.hpp
@@ -46,7 +46,7 @@
 #include "simd_common.hpp"
 
 #ifdef __HIPCC__
-#define SIMD_CUDA_ALWAYS_INLINE __forceinline__
+#define SIMD_HIP_ALWAYS_INLINE __forceinline__
 #endif
 
 #ifdef __HIPCC__
@@ -118,39 +118,39 @@ class simd_mask<T, simd_abi::hip_wavefront<N>> {
   using value_type = bool;
   using abi_type = simd_abi::hip_wavefront<N>;
   using simd_type = simd<T, abi_type>;
-  SIMD_CUDA_ALWAYS_INLINE simd_mask() = default;
+  SIMD_HIP_ALWAYS_INLINE simd_mask() = default;
   SIMD_ALWAYS_INLINE SIMD_HOST_DEVICE static constexpr
   int size() { return N; }
-  SIMD_CUDA_ALWAYS_INLINE SIMD_DEVICE
+  SIMD_HIP_ALWAYS_INLINE SIMD_DEVICE
   simd_mask(bool value)
     :m_value(value)
   {}
-  SIMD_CUDA_ALWAYS_INLINE SIMD_DEVICE constexpr
+  SIMD_HIP_ALWAYS_INLINE SIMD_DEVICE constexpr
   bool get() const {
     return m_value;
   }
-  SIMD_CUDA_ALWAYS_INLINE SIMD_DEVICE
+  SIMD_HIP_ALWAYS_INLINE SIMD_DEVICE
   simd_mask operator||(simd_mask const& other) const {
     return m_value || other.m_value;
   }
-  SIMD_CUDA_ALWAYS_INLINE SIMD_DEVICE
+  SIMD_HIP_ALWAYS_INLINE SIMD_DEVICE
   simd_mask operator&&(simd_mask const& other) const {
     return m_value && other.m_value;
   }
-  SIMD_CUDA_ALWAYS_INLINE SIMD_DEVICE
+  SIMD_HIP_ALWAYS_INLINE SIMD_DEVICE
   simd_mask operator!() const {
     return !m_value;
   }
 };
 
 template <class T, int N>
-SIMD_CUDA_ALWAYS_INLINE SIMD_DEVICE
+SIMD_HIP_ALWAYS_INLINE SIMD_DEVICE
 bool all_of(simd_mask<T, simd_abi::hip_wavefront<N>> const& a) {
   return bool(__all_sync(simd_abi::hip_wavefront<N>::mask(), int(a.get())));
 }
 
 template <class T, int N>
-SIMD_CUDA_ALWAYS_INLINE SIMD_DEVICE
+SIMD_HIP_ALWAYS_INLINE SIMD_DEVICE
 bool any_of(simd_mask<T, simd_abi::hip_wavefront<N>> const& a) {
   return bool(__any_sync(simd_abi::hip_wavefront<N>::mask(), int(a.get())));
 }
@@ -163,80 +163,80 @@ class simd<T, simd_abi::hip_wavefront<N>> {
   using abi_type = simd_abi::hip_wavefront<N>;
   using mask_type = simd_mask<T, abi_type>;
   using storage_type = simd_storage<T, abi_type>;
-  SIMD_CUDA_ALWAYS_INLINE simd() = default;
-  SIMD_CUDA_ALWAYS_INLINE SIMD_HOST_DEVICE static constexpr int size() { return N; }
-  SIMD_CUDA_ALWAYS_INLINE SIMD_DEVICE simd(T value)
+  SIMD_HIP_ALWAYS_INLINE simd() = default;
+  SIMD_HIP_ALWAYS_INLINE SIMD_HOST_DEVICE static constexpr int size() { return N; }
+  SIMD_HIP_ALWAYS_INLINE SIMD_DEVICE simd(T value)
     :m_value(value)
   {}
-  SIMD_CUDA_ALWAYS_INLINE SIMD_DEVICE
+  SIMD_HIP_ALWAYS_INLINE SIMD_DEVICE
   simd(storage_type const& value) {
     copy_from(value.data(), element_aligned_tag());
   }
-  SIMD_CUDA_ALWAYS_INLINE SIMD_DEVICE
+  SIMD_HIP_ALWAYS_INLINE SIMD_DEVICE
   simd& operator=(storage_type const& value) {
     copy_from(value.data(), element_aligned_tag());
     return *this;
   }
   template <class Flags>
-  SIMD_CUDA_ALWAYS_INLINE SIMD_DEVICE simd(T const* ptr, Flags flags) {
+  SIMD_HIP_ALWAYS_INLINE SIMD_DEVICE simd(T const* ptr, Flags flags) {
     copy_from(ptr, flags);
   }
-  SIMD_CUDA_ALWAYS_INLINE SIMD_DEVICE simd operator*(simd const& other) const {
+  SIMD_HIP_ALWAYS_INLINE SIMD_DEVICE simd operator*(simd const& other) const {
     return simd(m_value * other.m_value);
   }
-  SIMD_CUDA_ALWAYS_INLINE SIMD_DEVICE simd operator/(simd const& other) const {
+  SIMD_HIP_ALWAYS_INLINE SIMD_DEVICE simd operator/(simd const& other) const {
     return simd(m_value / other.m_value);
   }
-  SIMD_CUDA_ALWAYS_INLINE SIMD_DEVICE simd operator+(simd const& other) const {
+  SIMD_HIP_ALWAYS_INLINE SIMD_DEVICE simd operator+(simd const& other) const {
     return simd(m_value + other.m_value);
   }
-  SIMD_CUDA_ALWAYS_INLINE SIMD_DEVICE simd operator-(simd const& other) const {
+  SIMD_HIP_ALWAYS_INLINE SIMD_DEVICE simd operator-(simd const& other) const {
     return simd(m_value - other.m_value);
   }
-  SIMD_CUDA_ALWAYS_INLINE SIMD_DEVICE simd operator-() const {
+  SIMD_HIP_ALWAYS_INLINE SIMD_DEVICE simd operator-() const {
     return simd(-m_value);
   }
-  SIMD_CUDA_ALWAYS_INLINE SIMD_DEVICE void copy_from(T const* ptr, element_aligned_tag) {
+  SIMD_HIP_ALWAYS_INLINE SIMD_DEVICE void copy_from(T const* ptr, element_aligned_tag) {
     m_value = ptr[threadIdx.x];
   }
-  SIMD_CUDA_ALWAYS_INLINE SIMD_DEVICE void copy_to(T* ptr, element_aligned_tag) const {
+  SIMD_HIP_ALWAYS_INLINE SIMD_DEVICE void copy_to(T* ptr, element_aligned_tag) const {
     ptr[threadIdx.x] = m_value;
   }
-  SIMD_CUDA_ALWAYS_INLINE SIMD_DEVICE T get() const {
+  SIMD_HIP_ALWAYS_INLINE SIMD_DEVICE T get() const {
     return m_value;
   }
-  SIMD_CUDA_ALWAYS_INLINE SIMD_DEVICE
+  SIMD_HIP_ALWAYS_INLINE SIMD_DEVICE
   mask_type operator<(simd const& other) const {
     return mask_type(m_value < other.m_value);
   }
-  SIMD_CUDA_ALWAYS_INLINE SIMD_DEVICE
+  SIMD_HIP_ALWAYS_INLINE SIMD_DEVICE
   mask_type operator==(simd const& other) const {
     return mask_type(m_value == other.m_value);
   }
 };
 
 template <class T, int N>
-SIMD_CUDA_ALWAYS_INLINE SIMD_HOST_DEVICE simd<T, simd_abi::hip_wavefront<N>> abs(simd<T, simd_abi::hip_wavefront<N>> const& a) {
-  return simd<T, simd_abi::hip_wavefront<N>>(std::abs(a.get()));
+SIMD_HIP_ALWAYS_INLINE SIMD_HOST_DEVICE simd<T, simd_abi::hip_wavefront<N>> abs(simd<T, simd_abi::hip_wavefront<N>> const& a) {
+  return simd<T, simd_abi::hip_wavefront<N>>(abs(a.get()));
 }
 
 template <class T, int N>
-SIMD_CUDA_ALWAYS_INLINE SIMD_HOST_DEVICE simd<T, simd_abi::hip_wavefront<N>> sqrt(simd<T, simd_abi::hip_wavefront<N>> const& a) {
-  return simd<T, simd_abi::hip_wavefront<N>>(std::sqrt(a.get()));
+SIMD_HIP_ALWAYS_INLINE SIMD_HOST_DEVICE simd<T, simd_abi::hip_wavefront<N>> sqrt(simd<T, simd_abi::hip_wavefront<N>> const& a) {
+  return simd<T, simd_abi::hip_wavefront<N>>(sqrt(a.get()));
 }
 
 template <class T, int N>
-SIMD_CUDA_ALWAYS_INLINE SIMD_HOST_DEVICE simd<T, simd_abi::hip_wavefront<N>> cbrt(simd<T, simd_abi::hip_wavefront<N>> const& a) {
-  return simd<T, simd_abi::hip_wavefront<N>>(std::cbrt(a.get()));
+SIMD_HIP_ALWAYS_INLINE SIMD_HOST_DEVICE simd<T, simd_abi::hip_wavefront<N>> cbrt(simd<T, simd_abi::hip_wavefront<N>> const& a) {
+  return simd<T, simd_abi::hip_wavefront<N>>(cbrt(a.get()));
 }
 
 template <class T, int N>
-SIMD_CUDA_ALWAYS_INLINE SIMD_HOST_DEVICE simd<T, simd_abi::hip_wavefront<N>> exp(simd<T, simd_abi::hip_wavefront<N>> const& a) {
-  return simd<T, simd_abi::hip_wavefront<N>>(std::exp(a.get()));
+SIMD_HIP_ALWAYS_INLINE SIMD_HOST_DEVICE simd<T, simd_abi::hip_wavefront<N>> exp(simd<T, simd_abi::hip_wavefront<N>> const& a) {
+  return simd<T, simd_abi::hip_wavefront<N>>(exp(a.get()));
 }
 
 template <class T, int N>
-SIMD_CUDA_ALWAYS_INLINE SIMD_HOST_DEVICE simd<T, simd_abi::hip_wavefront<N>> fma(
+SIMD_HIP_ALWAYS_INLINE SIMD_HOST_DEVICE simd<T, simd_abi::hip_wavefront<N>> fma(
     simd<T, simd_abi::hip_wavefront<N>> const& a,
     simd<T, simd_abi::hip_wavefront<N>> const& b,
     simd<T, simd_abi::hip_wavefront<N>> const& c) {
@@ -244,19 +244,19 @@ SIMD_CUDA_ALWAYS_INLINE SIMD_HOST_DEVICE simd<T, simd_abi::hip_wavefront<N>> fma
 }
 
 template <class T, int N>
-SIMD_CUDA_ALWAYS_INLINE SIMD_HOST_DEVICE simd<T, simd_abi::hip_wavefront<N>> max(
+SIMD_HIP_ALWAYS_INLINE SIMD_HOST_DEVICE simd<T, simd_abi::hip_wavefront<N>> max(
     simd<T, simd_abi::hip_wavefront<N>> const& a, simd<T, simd_abi::hip_wavefront<N>> const& b) {
   return simd<T, simd_abi::hip_wavefront<N>>((a.get() < b.get()) ? b.get() : a.get());
 }
 
 template <class T, int N>
-SIMD_CUDA_ALWAYS_INLINE SIMD_HOST_DEVICE simd<T, simd_abi::hip_wavefront<N>> min(
+SIMD_HIP_ALWAYS_INLINE SIMD_HOST_DEVICE simd<T, simd_abi::hip_wavefront<N>> min(
     simd<T, simd_abi::hip_wavefront<N>> const& a, simd<T, simd_abi::hip_wavefront<N>> const& b) {
   return simd<T, simd_abi::hip_wavefront<N>>((b.get() < a.get()) ? b.get() : a.get());
 }
 
 template <class T, int N>
-SIMD_CUDA_ALWAYS_INLINE SIMD_HOST_DEVICE simd<T, simd_abi::hip_wavefront<N>> choose(
+SIMD_HIP_ALWAYS_INLINE SIMD_HOST_DEVICE simd<T, simd_abi::hip_wavefront<N>> choose(
     simd_mask<T, simd_abi::hip_wavefront<N>> const& a,
     simd<T, simd_abi::hip_wavefront<N>> const& b,
     simd<T, simd_abi::hip_wavefront<N>> const& c) {

--- a/hip_wavefront.hpp
+++ b/hip_wavefront.hpp
@@ -197,10 +197,10 @@ class simd<T, simd_abi::hip_wavefront<N>> {
     return simd(-m_value);
   }
   SIMD_HIP_ALWAYS_INLINE SIMD_DEVICE void copy_from(T const* ptr, element_aligned_tag) {
-    m_value = ptr[threadIdx.x];
+    m_value = ptr[hipThreadIdx_x];
   }
   SIMD_HIP_ALWAYS_INLINE SIMD_DEVICE void copy_to(T* ptr, element_aligned_tag) const {
-    ptr[threadIdx.x] = m_value;
+    ptr[hipThreadIdx_x] = m_value;
   }
   SIMD_HIP_ALWAYS_INLINE SIMD_DEVICE T get() const {
     return m_value;

--- a/hip_wavefront.hpp
+++ b/hip_wavefront.hpp
@@ -62,6 +62,7 @@
 #endif
 
 #ifdef __HIPCC__
+#include <hip/math_functions.h>
 
 namespace SIMD_NAMESPACE {
 
@@ -217,46 +218,46 @@ class simd<T, simd_abi::hip_wavefront<N>> {
 
   // ABS
 template <int N>
-SIMD_HIP_ALWAYS_INLINE SIMD_HOST_DEVICE simd<float, simd_abi::hip_wavefront<N>> abs(simd<float, simd_abi::hip_wavefront<N>> const& a) {
+SIMD_HIP_ALWAYS_INLINE SIMD_DEVICE simd<float, simd_abi::hip_wavefront<N>> abs(simd<float, simd_abi::hip_wavefront<N>> const& a) {
   return simd<float, simd_abi::hip_wavefront<N>>(fabsf(a.get()));
 }
 
 template <int N>
-SIMD_HIP_ALWAYS_INLINE SIMD_HOST_DEVICE simd<double, simd_abi::hip_wavefront<N>> abs(simd<double, simd_abi::hip_wavefront<N>> const& a) {
+SIMD_HIP_ALWAYS_INLINE SIMD_DEVICE simd<double, simd_abi::hip_wavefront<N>> abs(simd<double, simd_abi::hip_wavefront<N>> const& a) {
   return simd<double, simd_abi::hip_wavefront<N>>(fabs(a.get()));
 }
 
   // SQRT
 template <int N>
-SIMD_HIP_ALWAYS_INLINE SIMD_HOST_DEVICE simd<float, simd_abi::hip_wavefront<N>> sqrt(simd<float, simd_abi::hip_wavefront<N>> const& a) {
+SIMD_HIP_ALWAYS_INLINE SIMD_DEVICE simd<float, simd_abi::hip_wavefront<N>> sqrt(simd<float, simd_abi::hip_wavefront<N>> const& a) {
   return simd<float, simd_abi::hip_wavefront<N>>(sqrtf(a.get()));
 }
 
 template <int N>
-SIMD_HIP_ALWAYS_INLINE SIMD_HOST_DEVICE simd<double, simd_abi::hip_wavefront<N>> sqrt(simd<double, simd_abi::hip_wavefront<N>> const& a) {
+SIMD_HIP_ALWAYS_INLINE SIMD_DEVICE simd<double, simd_abi::hip_wavefront<N>> sqrt(simd<double, simd_abi::hip_wavefront<N>> const& a) {
   return simd<double, simd_abi::hip_wavefront<N>>(sqrt(a.get()));
 }
 
   // CBRT
 template <int N>
-SIMD_HIP_ALWAYS_INLINE SIMD_HOST_DEVICE simd<float, simd_abi::hip_wavefront<N>> cbrt(simd<float, simd_abi::hip_wavefront<N>> const& a) {
+SIMD_HIP_ALWAYS_INLINE SIMD_DEVICE simd<float, simd_abi::hip_wavefront<N>> cbrt(simd<float, simd_abi::hip_wavefront<N>> const& a) {
   return simd<float, simd_abi::hip_wavefront<N>>(cbrtf(a.get()));
 }
 
 template <int N>
-SIMD_HIP_ALWAYS_INLINE SIMD_HOST_DEVICE simd<double, simd_abi::hip_wavefront<N>> cbrt(simd<double, simd_abi::hip_wavefront<N>> const& a) {
+SIMD_HIP_ALWAYS_INLINE SIMD_DEVICE simd<double, simd_abi::hip_wavefront<N>> cbrt(simd<double, simd_abi::hip_wavefront<N>> const& a) {
   return simd<double, simd_abi::hip_wavefront<N>>(cbrt(a.get()));
 }
 
   // EXP
 template <int N>
-SIMD_HIP_ALWAYS_INLINE SIMD_HOST_DEVICE simd<float, simd_abi::hip_wavefront<N>> exp(simd<float, simd_abi::hip_wavefront<N>> const& a) {
+SIMD_HIP_ALWAYS_INLINE SIMD_DEVICE simd<float, simd_abi::hip_wavefront<N>> exp(simd<float, simd_abi::hip_wavefront<N>> const& a) {
   return simd<float, simd_abi::hip_wavefront<N>>(expf(a.get()));
 }
 
   
 template <int N>
-SIMD_HIP_ALWAYS_INLINE SIMD_HOST_DEVICE simd<double, simd_abi::hip_wavefront<N>> exp(simd<double, simd_abi::hip_wavefront<N>> const& a) {
+SIMD_HIP_ALWAYS_INLINE SIMD_DEVICE simd<double, simd_abi::hip_wavefront<N>> exp(simd<double, simd_abi::hip_wavefront<N>> const& a) {
   return simd<double, simd_abi::hip_wavefront<N>>(exp(a.get()));
 }
 

--- a/hip_wavefront.hpp
+++ b/hip_wavefront.hpp
@@ -219,46 +219,46 @@ class simd<T, simd_abi::hip_wavefront<N>> {
   // ABS
 template <int N>
 SIMD_HIP_ALWAYS_INLINE SIMD_DEVICE simd<float, simd_abi::hip_wavefront<N>> abs(simd<float, simd_abi::hip_wavefront<N>> const& a) {
-  return simd<float, simd_abi::hip_wavefront<N>>(fabsf(a.get()));
+  return simd<float, simd_abi::hip_wavefront<N>>(::fabsf(a.get()));
 }
 
 template <int N>
 SIMD_HIP_ALWAYS_INLINE SIMD_DEVICE simd<double, simd_abi::hip_wavefront<N>> abs(simd<double, simd_abi::hip_wavefront<N>> const& a) {
-  return simd<double, simd_abi::hip_wavefront<N>>(fabs(a.get()));
+  return simd<double, simd_abi::hip_wavefront<N>>(::fabs(a.get()));
 }
 
   // SQRT
 template <int N>
 SIMD_HIP_ALWAYS_INLINE SIMD_DEVICE simd<float, simd_abi::hip_wavefront<N>> sqrt(simd<float, simd_abi::hip_wavefront<N>> const& a) {
-  return simd<float, simd_abi::hip_wavefront<N>>(sqrtf(a.get()));
+  return simd<float, simd_abi::hip_wavefront<N>>(::sqrtf(a.get()));
 }
 
 template <int N>
 SIMD_HIP_ALWAYS_INLINE SIMD_DEVICE simd<double, simd_abi::hip_wavefront<N>> sqrt(simd<double, simd_abi::hip_wavefront<N>> const& a) {
-  return simd<double, simd_abi::hip_wavefront<N>>(sqrt(a.get()));
+  return simd<double, simd_abi::hip_wavefront<N>>(::sqrt(a.get()));
 }
 
   // CBRT
 template <int N>
 SIMD_HIP_ALWAYS_INLINE SIMD_DEVICE simd<float, simd_abi::hip_wavefront<N>> cbrt(simd<float, simd_abi::hip_wavefront<N>> const& a) {
-  return simd<float, simd_abi::hip_wavefront<N>>(cbrtf(a.get()));
+  return simd<float, simd_abi::hip_wavefront<N>>(::cbrtf(a.get()));
 }
 
 template <int N>
 SIMD_HIP_ALWAYS_INLINE SIMD_DEVICE simd<double, simd_abi::hip_wavefront<N>> cbrt(simd<double, simd_abi::hip_wavefront<N>> const& a) {
-  return simd<double, simd_abi::hip_wavefront<N>>(cbrt(a.get()));
+  return simd<double, simd_abi::hip_wavefront<N>>(::cbrt(a.get()));
 }
 
   // EXP
 template <int N>
 SIMD_HIP_ALWAYS_INLINE SIMD_DEVICE simd<float, simd_abi::hip_wavefront<N>> exp(simd<float, simd_abi::hip_wavefront<N>> const& a) {
-  return simd<float, simd_abi::hip_wavefront<N>>(expf(a.get()));
+  return simd<float, simd_abi::hip_wavefront<N>>(::expf(a.get()));
 }
 
   
 template <int N>
 SIMD_HIP_ALWAYS_INLINE SIMD_DEVICE simd<double, simd_abi::hip_wavefront<N>> exp(simd<double, simd_abi::hip_wavefront<N>> const& a) {
-  return simd<double, simd_abi::hip_wavefront<N>>(exp(a.get()));
+  return simd<double, simd_abi::hip_wavefront<N>>(::exp(a.get()));
 }
 
 template <class T, int N>

--- a/hip_wavefront.hpp
+++ b/hip_wavefront.hpp
@@ -1,0 +1,268 @@
+/*
+//@HEADER
+// ************************************************************************
+//
+//                        Kokkos v. 2.0
+//              Copyright (2014) Sandia Corporation
+//
+// Under the terms of Contract DE-AC04-94AL85000 with Sandia Corporation,
+// the U.S. Government retains certain rights in this software.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are
+// met:
+//
+// 1. Redistributions of source code must retain the above copyright
+// notice, this list of conditions and the following disclaimer.
+//
+// 2. Redistributions in binary form must reproduce the above copyright
+// notice, this list of conditions and the following disclaimer in the
+// documentation and/or other materials provided with the distribution.
+//
+// 3. Neither the name of the Corporation nor the names of the
+// contributors may be used to endorse or promote products derived from
+// this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY SANDIA CORPORATION "AS IS" AND ANY
+// EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+// PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL SANDIA CORPORATION OR THE
+// CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+// EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+// PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+// PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+// LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+// NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+// SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+//
+// Questions? Contact Christian R. Trott (crtrott@sandia.gov)
+//
+// ************************************************************************
+//@HEADER
+*/
+
+#pragma once
+
+#include "simd_common.hpp"
+
+#ifdef __HIPCC__
+#define SIMD_CUDA_ALWAYS_INLINE __forceinline__
+#endif
+
+#ifdef __HIPCC__
+#define SIMD_HOST_DEVICE __host__ __device__
+#else
+#define SIMD_HOST_DEVICE
+#endif
+
+#ifdef __HIPCC__
+#define SIMD_DEVICE __device__
+#else
+#define SIMD_DEVICE
+#endif
+
+#ifdef __HIPCC__
+
+namespace SIMD_NAMESPACE {
+
+namespace simd_abi {
+
+template <int N>
+class hip_wavefront {
+  static_assert(N <= 64, "HIP wavefronts can't be more than 64 threads");
+ public:
+  SIMD_HOST_DEVICE static unsigned mask() {
+    return (unsigned(1) << N) - unsigned(1);
+  }
+};
+
+}
+
+template <class T, int N>
+class simd_storage<T, simd_abi::hip_wavefront<N>> {
+  T m_value[simd<T, simd_abi::hip_wavefront<N>>::size()];
+ public:
+  using value_type = T;
+  using abi_type = simd_abi::hip_wavefront<N>;
+  using simd_type = simd<T, abi_type>;
+  SIMD_ALWAYS_INLINE inline simd_storage() = default;
+  SIMD_ALWAYS_INLINE SIMD_HOST_DEVICE inline static constexpr
+  int size() { return simd<T, abi_type>::size(); }
+  SIMD_ALWAYS_INLINE SIMD_HOST_DEVICE inline
+  simd_storage(simd<T, abi_type> const& value) {
+    value.copy_to(m_value, element_aligned_tag());
+  }
+  SIMD_ALWAYS_INLINE SIMD_HOST_DEVICE explicit inline
+  simd_storage(T value)
+    :simd_storage(simd<T, abi_type>(value))
+  {}
+  SIMD_ALWAYS_INLINE SIMD_HOST_DEVICE inline
+  simd_storage& operator=(simd<T, abi_type> const& value) {
+    value.copy_to(m_value, element_aligned_tag());
+    return *this;
+  }
+  SIMD_ALWAYS_INLINE SIMD_HOST_DEVICE
+  T const* data() const { return m_value; }
+  SIMD_ALWAYS_INLINE SIMD_HOST_DEVICE
+  T* data() { return m_value; }
+  SIMD_ALWAYS_INLINE SIMD_HOST_DEVICE
+  T const& operator[](int i) const { return m_value[i]; }
+  SIMD_ALWAYS_INLINE SIMD_HOST_DEVICE
+  T& operator[](int i) { return m_value[i]; }
+};
+
+template <class T, int N>
+class simd_mask<T, simd_abi::hip_wavefront<N>> {
+  bool m_value;
+ public:
+  using value_type = bool;
+  using abi_type = simd_abi::hip_wavefront<N>;
+  using simd_type = simd<T, abi_type>;
+  SIMD_CUDA_ALWAYS_INLINE simd_mask() = default;
+  SIMD_ALWAYS_INLINE SIMD_HOST_DEVICE static constexpr
+  int size() { return N; }
+  SIMD_CUDA_ALWAYS_INLINE SIMD_DEVICE
+  simd_mask(bool value)
+    :m_value(value)
+  {}
+  SIMD_CUDA_ALWAYS_INLINE SIMD_DEVICE constexpr
+  bool get() const {
+    return m_value;
+  }
+  SIMD_CUDA_ALWAYS_INLINE SIMD_DEVICE
+  simd_mask operator||(simd_mask const& other) const {
+    return m_value || other.m_value;
+  }
+  SIMD_CUDA_ALWAYS_INLINE SIMD_DEVICE
+  simd_mask operator&&(simd_mask const& other) const {
+    return m_value && other.m_value;
+  }
+  SIMD_CUDA_ALWAYS_INLINE SIMD_DEVICE
+  simd_mask operator!() const {
+    return !m_value;
+  }
+};
+
+template <class T, int N>
+SIMD_CUDA_ALWAYS_INLINE SIMD_DEVICE
+bool all_of(simd_mask<T, simd_abi::hip_wavefront<N>> const& a) {
+  return bool(__all_sync(simd_abi::hip_wavefront<N>::mask(), int(a.get())));
+}
+
+template <class T, int N>
+SIMD_CUDA_ALWAYS_INLINE SIMD_DEVICE
+bool any_of(simd_mask<T, simd_abi::hip_wavefront<N>> const& a) {
+  return bool(__any_sync(simd_abi::hip_wavefront<N>::mask(), int(a.get())));
+}
+
+template <class T, int N>
+class simd<T, simd_abi::hip_wavefront<N>> {
+  T m_value;
+ public:
+  using value_type = T;
+  using abi_type = simd_abi::hip_wavefront<N>;
+  using mask_type = simd_mask<T, abi_type>;
+  using storage_type = simd_storage<T, abi_type>;
+  SIMD_CUDA_ALWAYS_INLINE simd() = default;
+  SIMD_CUDA_ALWAYS_INLINE SIMD_HOST_DEVICE static constexpr int size() { return N; }
+  SIMD_CUDA_ALWAYS_INLINE SIMD_DEVICE simd(T value)
+    :m_value(value)
+  {}
+  SIMD_CUDA_ALWAYS_INLINE SIMD_DEVICE
+  simd(storage_type const& value) {
+    copy_from(value.data(), element_aligned_tag());
+  }
+  SIMD_CUDA_ALWAYS_INLINE SIMD_DEVICE
+  simd& operator=(storage_type const& value) {
+    copy_from(value.data(), element_aligned_tag());
+    return *this;
+  }
+  template <class Flags>
+  SIMD_CUDA_ALWAYS_INLINE SIMD_DEVICE simd(T const* ptr, Flags flags) {
+    copy_from(ptr, flags);
+  }
+  SIMD_CUDA_ALWAYS_INLINE SIMD_DEVICE simd operator*(simd const& other) const {
+    return simd(m_value * other.m_value);
+  }
+  SIMD_CUDA_ALWAYS_INLINE SIMD_DEVICE simd operator/(simd const& other) const {
+    return simd(m_value / other.m_value);
+  }
+  SIMD_CUDA_ALWAYS_INLINE SIMD_DEVICE simd operator+(simd const& other) const {
+    return simd(m_value + other.m_value);
+  }
+  SIMD_CUDA_ALWAYS_INLINE SIMD_DEVICE simd operator-(simd const& other) const {
+    return simd(m_value - other.m_value);
+  }
+  SIMD_CUDA_ALWAYS_INLINE SIMD_DEVICE simd operator-() const {
+    return simd(-m_value);
+  }
+  SIMD_CUDA_ALWAYS_INLINE SIMD_DEVICE void copy_from(T const* ptr, element_aligned_tag) {
+    m_value = ptr[threadIdx.x];
+  }
+  SIMD_CUDA_ALWAYS_INLINE SIMD_DEVICE void copy_to(T* ptr, element_aligned_tag) const {
+    ptr[threadIdx.x] = m_value;
+  }
+  SIMD_CUDA_ALWAYS_INLINE SIMD_DEVICE T get() const {
+    return m_value;
+  }
+  SIMD_CUDA_ALWAYS_INLINE SIMD_DEVICE
+  mask_type operator<(simd const& other) const {
+    return mask_type(m_value < other.m_value);
+  }
+  SIMD_CUDA_ALWAYS_INLINE SIMD_DEVICE
+  mask_type operator==(simd const& other) const {
+    return mask_type(m_value == other.m_value);
+  }
+};
+
+template <class T, int N>
+SIMD_CUDA_ALWAYS_INLINE SIMD_HOST_DEVICE simd<T, simd_abi::hip_wavefront<N>> abs(simd<T, simd_abi::hip_wavefront<N>> const& a) {
+  return simd<T, simd_abi::hip_wavefront<N>>(std::abs(a.get()));
+}
+
+template <class T, int N>
+SIMD_CUDA_ALWAYS_INLINE SIMD_HOST_DEVICE simd<T, simd_abi::hip_wavefront<N>> sqrt(simd<T, simd_abi::hip_wavefront<N>> const& a) {
+  return simd<T, simd_abi::hip_wavefront<N>>(std::sqrt(a.get()));
+}
+
+template <class T, int N>
+SIMD_CUDA_ALWAYS_INLINE SIMD_HOST_DEVICE simd<T, simd_abi::hip_wavefront<N>> cbrt(simd<T, simd_abi::hip_wavefront<N>> const& a) {
+  return simd<T, simd_abi::hip_wavefront<N>>(std::cbrt(a.get()));
+}
+
+template <class T, int N>
+SIMD_CUDA_ALWAYS_INLINE SIMD_HOST_DEVICE simd<T, simd_abi::hip_wavefront<N>> exp(simd<T, simd_abi::hip_wavefront<N>> const& a) {
+  return simd<T, simd_abi::hip_wavefront<N>>(std::exp(a.get()));
+}
+
+template <class T, int N>
+SIMD_CUDA_ALWAYS_INLINE SIMD_HOST_DEVICE simd<T, simd_abi::hip_wavefront<N>> fma(
+    simd<T, simd_abi::hip_wavefront<N>> const& a,
+    simd<T, simd_abi::hip_wavefront<N>> const& b,
+    simd<T, simd_abi::hip_wavefront<N>> const& c) {
+  return simd<T, simd_abi::hip_wavefront<N>>((a.get() * b.get()) + c.get());
+}
+
+template <class T, int N>
+SIMD_CUDA_ALWAYS_INLINE SIMD_HOST_DEVICE simd<T, simd_abi::hip_wavefront<N>> max(
+    simd<T, simd_abi::hip_wavefront<N>> const& a, simd<T, simd_abi::hip_wavefront<N>> const& b) {
+  return simd<T, simd_abi::hip_wavefront<N>>((a.get() < b.get()) ? b.get() : a.get());
+}
+
+template <class T, int N>
+SIMD_CUDA_ALWAYS_INLINE SIMD_HOST_DEVICE simd<T, simd_abi::hip_wavefront<N>> min(
+    simd<T, simd_abi::hip_wavefront<N>> const& a, simd<T, simd_abi::hip_wavefront<N>> const& b) {
+  return simd<T, simd_abi::hip_wavefront<N>>((b.get() < a.get()) ? b.get() : a.get());
+}
+
+template <class T, int N>
+SIMD_CUDA_ALWAYS_INLINE SIMD_HOST_DEVICE simd<T, simd_abi::hip_wavefront<N>> choose(
+    simd_mask<T, simd_abi::hip_wavefront<N>> const& a,
+    simd<T, simd_abi::hip_wavefront<N>> const& b,
+    simd<T, simd_abi::hip_wavefront<N>> const& c) {
+  return simd<T, simd_abi::hip_wavefront<N>>(a.get() ? b.get() : c.get());
+}
+
+}
+
+#endif

--- a/simd.hpp
+++ b/simd.hpp
@@ -53,8 +53,11 @@
 #include "vector_size.hpp"
 #endif
 
-#ifdef __CUDACC__
+#if defined( __CUDACC__ )
 #include "cuda_warp.hpp"
+
+#elif defined( __HIPCC__ )
+#include "hip_wavefront.hpp"
 
 #else
 
@@ -85,6 +88,8 @@ namespace SIMD_NAMESPACE {
 namespace simd_abi {
 
 #if defined(__CUDACC__)
+using native = scalar;
+#elif defined(__HIPCC__) 
 using native = scalar;
 #elif defined(__AVX512F__)
 using native = avx512;

--- a/simd_common.hpp
+++ b/simd_common.hpp
@@ -50,9 +50,14 @@
 #define SIMD_ALWAYS_INLINE [[gnu::always_inline]]
 #endif
 
-#if defined( __CUDACC__ ) || defined( __HIPCC__ )
+#if defined( __CUDACC__ )
 #define SIMD_CUDA_ALWAYS_INLINE __forceinline__
 #endif
+
+#if defined( __HIPCC__ )
+#define SIMD_HIP_ALWAYS_INLINE __forceinline__
+#endif
+
 
 #if defined( __CUDACC__) || defined( __HIPCC__ )
 #define SIMD_HOST_DEVICE __host__ __device__

--- a/simd_common.hpp
+++ b/simd_common.hpp
@@ -50,17 +50,17 @@
 #define SIMD_ALWAYS_INLINE [[gnu::always_inline]]
 #endif
 
-#ifdef __CUDACC__
+#if defined( __CUDACC__ ) || defined( __HIPCC__ )
 #define SIMD_CUDA_ALWAYS_INLINE __forceinline__
 #endif
 
-#ifdef __CUDACC__
+#if defined( __CUDACC__) || defined( __HIPCC__ )
 #define SIMD_HOST_DEVICE __host__ __device__
 #else
 #define SIMD_HOST_DEVICE
 #endif
 
-#ifdef __CUDACC__
+#if defined (__CUDACC__) || defined( __HIPCC__ )
 #define SIMD_DEVICE __device__
 #else
 #define SIMD_DEVICE


### PR DESCRIPTION
Hi All, 
 Here is my attempt at porting the CUDA  simd::abi::cuda_warp<N> to HIP (specifically to hip::simd_abi::hip_wavefront<N> with N <=64. 

I wrote a separate testsuite to test specifically the function calls at https://github.com/bjoo/simd-math-testing.git. I am not averse to that being extended for SIMD testing.

Many thanks to @Rombur for pointing out things like threadIdx.x to hipThreadIdx_x and that I need to deal carefully with the math functions (which turned out to be a more tricky slog than I thought -- again I needed to explicitly disambiguate at the lowest level to use ::exp, ::sqrt etc otherwise the compiler got confused. 

Hope this is a helpful addition, Best, B 