### PR TITLE
Feature/permute rebase13

### DIFF
--- a/cuda_warp.hpp
+++ b/cuda_warp.hpp
@@ -72,7 +72,8 @@ class cuda_warp {
   static_assert(N <= 32, "CUDA warps can't be more than 32 threads");
  public:
   SIMD_HOST_DEVICE static unsigned mask() {
-    return (unsigned(1) << N) - unsigned(1);
+
+    return N == 32 ? 0xffffffff : ( (unsigned(1) << N) - unsigned(1) ) ;
   }
 };
 
@@ -266,6 +267,14 @@ SIMD_CUDA_ALWAYS_INLINE SIMD_HOST_DEVICE simd<T, simd_abi::cuda_warp<N>> choose(
     simd<T, simd_abi::cuda_warp<N>> const& c) {
   return simd<T, simd_abi::cuda_warp<N>>(a.get() ? b.get() : c.get());
 }
+
+  // Generic Permute
+  template <class T, int N>
+SIMD_ALWAYS_INLINE SIMD_HOST_DEVICE
+  inline simd<T, simd_abi::cuda_warp<N>> permute(simd<int, simd_abi::cuda_warp<N>> const& control, simd<T, simd_abi::cuda_warp<N>> const& a) {
+    return simd<T,simd_abi::cuda_warp<N>>(  __shfl_sync(simd_abi::cuda_warp<N>::mask(), a.get(),  control.get(), N));
+  }
+
 
 }
 

--- a/simd_common.hpp
+++ b/simd_common.hpp
@@ -279,7 +279,10 @@ class simd_size<simd<T, Abi>> {
 };
 
 
-// Generic Permute
+// Generic Permute -- does not work on GPUs
+// FIXME: This guard is not sufficient: it should guard against 
+// General Clang GPU Combinations too
+#if !defined(__CUDACC__) && !defined(__HIPCC__)
 template <class T, class Abi>
 SIMD_ALWAYS_INLINE SIMD_HOST_DEVICE
 inline simd<T, Abi> permute(simd<int, Abi> const& control, simd<T, Abi> const& a) {
@@ -297,5 +300,6 @@ inline simd<T, Abi> permute(simd<int, Abi> const& control, simd<T, Abi> const& a
   result.copy_from(stack_res, element_aligned_tag());
   return result;
 }
+#endif
 
 }

--- a/simd_common.hpp
+++ b/simd_common.hpp
@@ -278,4 +278,24 @@ class simd_size<simd<T, Abi>> {
   static constexpr int value = simd<T, Abi>::size();
 };
 
+
+// Generic Permute
+template <class T, class Abi>
+SIMD_ALWAYS_INLINE SIMD_HOST_DEVICE
+inline simd<T, Abi> permute(simd<int, Abi> const& control, simd<T, Abi> const& a) {
+  T stack_a[simd<T, Abi>::size()];
+  T stack_res[simd<T,Abi>::size()];
+  int stack_control[ simd<T,Abi>::size()];
+
+  a.copy_to(stack_a, element_aligned_tag());
+  control.copy_to(stack_control, element_aligned_tag());
+
+  for (int i = 0; i < simd<T, Abi>::size(); ++i) {
+	  stack_res[i] = stack_a[ stack_control[i] ];
+  }
+  simd<T,Abi> result;
+  result.copy_from(stack_res, element_aligned_tag());
+  return result;
+}
+
 }


### PR DESCRIPTION
Hi All, Here are the additions for vector lane permute. Intrinsics for AVX (Single Prec), AVX512 (single prec and double prec), Generic for other CPUs, __shfl_sync for CUDA, __shfl for HIP.  

I also came accross an overflow possibility with the CUDA masks when N=32 (got compiler warning) so I made that go away. 

A couple of FIXME's still left in there as well as a funny for AVX512 where the permutexvar intrinsic looks at every second element of the permutation index table register, and intevening elements are zeroed out, hence the funny 8 element constructor for the simd<int,> type. Maybe worth renaming these to something like simd_permute_control_t in the future. 

This was rebased onto master after #13 was merged.

The testing harness is at: https://github.com/bjoo/simd-math-testing.git and shows how the permutes are being called.
