### PR TITLE
Fixing a namespace / classname ambiguity

### DIFF
--- a/simd_common.hpp
+++ b/simd_common.hpp
@@ -183,7 +183,7 @@ SIMD_ALWAYS_INLINE SIMD_HOST_DEVICE inline simd<T, Abi> multiplysign(simd<T, Abi
   T tmp_b[simd<T, Abi>::size()];
   a.copy_to(tmp_a, element_aligned_tag());
   b.copy_to(tmp_b, element_aligned_tag());
-  for (int i = 0; i < simd<T, Abi>::size(); ++i) tmp_a[i] = tmp_a[i]*SIMD_NAMESPACE::copysign(static_cast<T>(1.0), tmp_b[i]);
+  for (int i = 0; i < simd<T, Abi>::size(); ++i) tmp_a[i] = tmp_a[i]*::SIMD_NAMESPACE::copysign(static_cast<T>(1.0), tmp_b[i]);
   a.copy_from(tmp_a, element_aligned_tag());
   return a;
 }
@@ -194,7 +194,7 @@ SIMD_ALWAYS_INLINE SIMD_HOST_DEVICE inline simd<T, Abi> copysign(simd<T, Abi> a,
   T tmp_b[simd<T, Abi>::size()];
   a.copy_to(tmp_a, element_aligned_tag());
   b.copy_to(tmp_b, element_aligned_tag());
-  for (int i = 0; i < simd<T, Abi>::size(); ++i) tmp_a[i] = SIMD_NAMESPACE::copysign(tmp_a[i], tmp_b[i]);
+  for (int i = 0; i < simd<T, Abi>::size(); ++i) tmp_a[i] = ::SIMD_NAMESPACE::copysign(tmp_a[i], tmp_b[i]);
   a.copy_from(tmp_a, element_aligned_tag());
   return a;
 }


### PR DESCRIPTION
WIth CUDA it was thinking that in simd::copysign simd is the class not the namespace.