### PR TITLE
Add SIMD_FORCE_SCALAR macro

### DIFF
--- a/simd.hpp
+++ b/simd.hpp
@@ -53,6 +53,7 @@
 #include "vector_size.hpp"
 #endif
 
+#ifndef SIMD_FORCE_SCALAR
 #if defined( __CUDACC__ )
 #include "cuda_warp.hpp"
 
@@ -82,12 +83,15 @@
 #endif
 
 #endif
+#endif
 
 namespace SIMD_NAMESPACE {
 
 namespace simd_abi {
 
-#if defined(__CUDACC__)
+#if defined(SIMD_FORCE_SCALAR)
+using native = scalar;
+#elif defined(__CUDACC__)
 using native = scalar;
 #elif defined(__HIPCC__) 
 using native = scalar;


### PR DESCRIPTION
@ibaned @alanw0 @ldh4 

Selects scalar and turns off compilation of intrinsics.  This is functionality that has been requested by multiple STK users as a workaround when intrinsics fail to compile.