### PR TITLE
Added missing decorations to some overloads

### DIFF
--- a/scalar.hpp
+++ b/scalar.hpp
@@ -140,7 +140,7 @@ class simd<T, simd_abi::scalar> {
     copy_from(value.data(), element_aligned_tag());
   }
 #ifdef STK_VOLATILE_SIMD
-  SIMD_ALWAYS_INLINE inline
+  SIMD_ALWAYS_INLINE SIMD_HOST_DEVICE inline
   simd(simd const volatile& value)
     :m_value(value.m_value)
   {}
@@ -167,7 +167,7 @@ class simd<T, simd_abi::scalar> {
     return simd(m_value + other.m_value);
   }
 #ifdef STK_VOLATILE_SIMD
-  SIMD_ALWAYS_INLINE inline void plus_equals(simd const volatile& other) volatile {
+  SIMD_ALWAYS_INLINE SIMD_HOST_DEVICE inline void plus_equals(simd const volatile& other) volatile {
     m_value = m_value + other.m_value;
   }
 #endif


### PR DESCRIPTION
@ibaned @alanw0 

The volatile overloads in scalar.hpp didn't have SIMD_HOST_DEVICE decorations, causing warnings on some platforms about calling a `__host__` function from a `__host__ __device__` function.