### PR TITLE
Fix compile error on clang

### DIFF
--- a/vector_size.hpp
+++ b/vector_size.hpp
@@ -146,7 +146,7 @@ class simd<T, simd_abi::vector_size<N>> {
   SIMD_ALWAYS_INLINE inline simd() = default;
   SIMD_ALWAYS_INLINE inline static constexpr int size() { return N / sizeof(T); }
   SIMD_ALWAYS_INLINE inline simd(T value) { for(int i=0; i<size(); i++) reinterpret_cast<T*>(&m_value)[i] = value; }
-  explicit SIMD_ALWAYS_INLINE inline simd(const native_type& value):m_value(value) {}
+  SIMD_ALWAYS_INLINE explicit inline simd(const native_type& value):m_value(value) {}
   SIMD_ALWAYS_INLINE inline
   simd(storage_type const& value) {
     copy_from(value.data(), element_aligned_tag());


### PR DESCRIPTION
Hi, this fixes the following compile error on clang:

```
/Users/keichi/Projects/kEDM/src/thirdparty/simd/vector_size.hpp:149:12: error: an attribute list cannot appear here
  explicit SIMD_ALWAYS_INLINE inline simd(const native_type& value):m_value(value) {}
           ^~~~~~~~~~~~~~~~~~
/Users/keichi/Projects/kEDM/src/thirdparty/simd/simd_common.hpp:52:28: note: expanded from macro 'SIMD_ALWAYS_INLINE'
#define SIMD_ALWAYS_INLINE [[gnu::always_inline]]
```

According to the C++ specs, attributes need to be placed before the function specifiers (c.f. https://omegaup.com/docs/cpp/en/cpp/language/function.html#Function_definition)